### PR TITLE
Fixed GLSL shaders compilation errors on OS X

### DIFF
--- a/DoomRPG/shaders/AuraIcon.fp
+++ b/DoomRPG/shaders/AuraIcon.fp
@@ -5,12 +5,12 @@ vec4 Process(vec4 color)
     float red = 0.5 + (sin(timer) * 0.5);
     float green = 0.5 + ((sin(timer) * 0.5) * (cos(timer) * 0.5));
     float blue = 0.5 + (cos(timer) * 0.5);
-    
-    vec4 input = getTexel(gl_TexCoord[0].st);
-    
-    input.r += red;
-    input.g += green;
-    input.b += blue;
-    
-    return color * input;
+
+    vec4 inputTexel = getTexel(gl_TexCoord[0].st);
+
+    inputTexel.r += red;
+    inputTexel.g += green;
+    inputTexel.b += blue;
+
+    return color * inputTexel;
 }

--- a/DoomRPG/shaders/BarFillFade.fp
+++ b/DoomRPG/shaders/BarFillFade.fp
@@ -5,11 +5,11 @@ vec4 Process(vec4 color)
     float red = color * (sin(timer) * 0.05);
     float green = color * (sin(timer) * 0.05);
     float blue = color * (sin(timer) * 0.05);
-    vec4 input = getTexel(gl_TexCoord[0].st);
-    
-    input.r += red;
-    input.g += green;
-    input.b += blue;
-    
-    return color * input;
+    vec4 inputTexel = getTexel(gl_TexCoord[0].st);
+
+    inputTexel.r += red;
+    inputTexel.g += green;
+    inputTexel.b += blue;
+
+    return color * inputTexel;
 }

--- a/DoomRPG/shaders/CrystalIcon.fp
+++ b/DoomRPG/shaders/CrystalIcon.fp
@@ -5,12 +5,12 @@ vec4 Process(vec4 color)
     float red = sin(timer) * 0.25;
     float green = (sin(timer) * 0.5) * (cos(timer) * 0.25);
     float blue = cos(timer) * 0.25;
-    
-    vec4 input = getTexel(gl_TexCoord[0].st);
-    
-    input.r += red;
-    input.g += green;
-    input.b += blue;
-    
-    return color * input;
+
+    vec4 inputTexel = getTexel(gl_TexCoord[0].st);
+
+    inputTexel.r += red;
+    inputTexel.g += green;
+    inputTexel.b += blue;
+
+    return color * inputTexel;
 }

--- a/DoomRPG/shaders/GlitchRows.fp
+++ b/DoomRPG/shaders/GlitchRows.fp
@@ -142,5 +142,5 @@ vec4 Process(vec4 color)
 
 	texCoord += offset;
 
-	return (getTexel(texCoord) * (1.0 - ((0.05 - abs (offset.x)) * 5))) * color;
+	return (getTexel(texCoord) * (1.0 - ((0.05 - abs (offset.x)) * 5.0))) * color;
 }

--- a/DoomRPG/shaders/ShieldColorPulse.fp
+++ b/DoomRPG/shaders/ShieldColorPulse.fp
@@ -5,12 +5,12 @@ vec4 Process(vec4 color)
     float red = 0.5 + (sin(timer) * 0.5);
     float green = 0.5 + ((sin(timer) * 0.5) * (cos(timer) * 0.5));
     float blue = 0.5 + (cos(timer) * 0.5);
-    
-    vec4 input = getTexel(gl_TexCoord[0].st);
-    
-    input.r += red;
-    input.g += green;
-    input.b += blue;
-    
-    return color * input;
+
+    vec4 inputTexel = getTexel(gl_TexCoord[0].st);
+
+    inputTexel.r += red;
+    inputTexel.g += green;
+    inputTexel.b += blue;
+
+    return color * inputTexel;
 }

--- a/DoomRPG/shaders/ShieldPulse.fp
+++ b/DoomRPG/shaders/ShieldPulse.fp
@@ -2,14 +2,14 @@ uniform float timer;
 
 vec4 Process(vec4 color)
 {
-    float red = color * (sin(timer) * 0.1);
-    float green = color * (sin(timer) * 0.1);
-    float blue = color * (sin(timer) * 0.1);
-    vec4 input = getTexel(gl_TexCoord[0].st);
-    
-    input.r += red;
-    input.g += green;
-    input.b += blue;
-    
-    return color * input;
+    float red = color.x * (sin(timer) * 0.1);
+    float green = color.y * (sin(timer) * 0.1);
+    float blue = color.z * (sin(timer) * 0.1);
+    vec4 inputTexel = getTexel(gl_TexCoord[0].st);
+
+    inputTexel.r += red;
+    inputTexel.g += green;
+    inputTexel.b += blue;
+
+    return color * inputTexel;
 }

--- a/DoomRPG/shaders/ShieldWarp.fp
+++ b/DoomRPG/shaders/ShieldWarp.fp
@@ -5,14 +5,14 @@ vec4 Process(vec4 color)
 	vec2 texCoord = gl_TexCoord[0].st;
 
 	const float pi = 3.14159265358979323846;
-    
-    vec4 input = getTexel(gl_TexCoord[0].st);
 
-	float offsetvalue = 0.125 * sin((pi * 2.0) * -timer + (sqrt (pow(0.5 - texCoord.y, 2) + pow(0.5 - texCoord.x, 2)) * 32.0));
-	input.r += offsetvalue;
-	input.g += offsetvalue;
-	input.b += offsetvalue;
+	vec4 inputTexel = getTexel(gl_TexCoord[0].st);
 
-	return input * color;
+	float offsetvalue = 0.125 * sin((pi * 2.0) * -timer + (sqrt (pow(0.5 - texCoord.y, 2.0) + pow(0.5 - texCoord.x, 2.0)) * 32.0));
+	inputTexel.r += offsetvalue;
+	inputTexel.g += offsetvalue;
+	inputTexel.b += offsetvalue;
+
+	return inputTexel * color;
 }
 


### PR DESCRIPTION
Fixed "'input' : Reserved word." in several shaders
Fixed "'*' does not operate on 'float' and 'int'" in GlitchRows shader
Fixed "Incompatible types in initialization (and no available implicit conversion)" in ShieldPulse shader
Fixed "No matching function for call to pow(float, int)" in ShieldWarp shader
