### PR TITLE
Make the focus mode's speed customizable.

### DIFF
--- a/DoomRPG/CVARINFO.txt
+++ b/DoomRPG/CVARINFO.txt
@@ -14,6 +14,8 @@ server  bool    drpg_monster_shadows = false;
 
 // Game Difficulty
 server	float   drpg_skill_costscale = 1.0;
+server	int     drpg_skill_focus_winduptime = 40;
+server	int     drpg_skill_focus_regensave = 35;
 server	bool 	drpg_skill_keepauras = false;
 server  int     drpg_skill_costcooldown = 10;
 server	bool	drpg_shield_reset = true;

--- a/DoomRPG/MENUDEF.txt
+++ b/DoomRPG/MENUDEF.txt
@@ -234,6 +234,11 @@ OptionMenu "DoomRPGDifficulty"
 	Option "Keep Auras between levels", "drpg_skill_keepauras", "OnOff"
 	Slider "Skill Cost Cooldown Time (Sec.)", "drpg_skill_costcooldown", 1, 60, 1
 	StaticText ""
+	
+	StaticText "Focus Mode wind-up time (sec.)"
+	Slider "Base time at 0 Regen", "drpg_skill_focus_winduptime", 1, 60, 1
+	Slider "Time saved at 200 Regen", "drpg_skill_focus_regensave", 0, 60, 1
+	StaticText ""
     
 	Option "Shields Drain when Deactivated", "drpg_shield_reset", "OnOff"
 	Option "Shield Removes Armor when Active", "drpg_shield_armorremove", "OnOff"

--- a/DoomRPG/scripts/RPG.ds
+++ b/DoomRPG/scripts/RPG.ds
@@ -1299,11 +1299,11 @@ acscript void ToggleFocusMode() net
 acscript void FocusMode()
 {
     int PrevEP = Player.EP;
-    int RegenWindupSpeed = ((35 * 40) - ((35 * 35) * Player.Regeneration / 200));
+    int RegenWindupSpeed = (35 * GetCVar("drpg_skill_focus_winduptime")) - ((35 * GetCVar("drpg_skill_focus_regensave")) * Player.Regeneration / 200);
     if (RegenWindupSpeed < 35) // Enforce a 1-second wind-up at least
         RegenWindupSpeed = 35;
     int StartWindupSpeed = RegenWindupSpeed;
-    int RegenDelay = (RegenWindupSpeed * (Player.EPTime / 4)) / StartWindupSpeed;
+    fixed RegenCounter = 0.0;
     
     // Return if you're already at max EP
     if (Player.EP >= Player.EPMax) return;
@@ -1327,14 +1327,20 @@ acscript void FocusMode()
         if (RegenWindupSpeed > 1)
             RegenWindupSpeed--;
         
-        if (RegenDelay > 0)
-            RegenDelay--
-        else
+        RegenCounter += AltCurve(
+            StartWindupSpeed - RegenWindupSpeed,
+            Percent >= 87 ? StartWindupSpeed * 0.87 : 0,
+            Percent >= 87 ? StartWindupSpeed : StartWindupSpeed * 0.87,
+            Percent >= 87 ? 0.03 : 0.007,
+            Percent >= 87 ? 0.4 : 0.03
+        );
+        
+        if (RegenWindupSpeed >= StartWindupSpeed || RegenCounter >= 1.0)
         {
             Player.EP += Player.EPAmount;
+            RegenCounter -= 1.0;
             if (Player.EP > Player.EPMax)
                 Player.EP = Player.EPMax;
-            RegenDelay = (RegenWindupSpeed * (Player.EPTime / 4)) / StartWindupSpeed;
         };
         
         if (Buttons > 0 || Player.EP >= Player.EPMax)


### PR DESCRIPTION
The proposed change makes the speed of the focus mode customizable. The user / server admin may choose how long focus mode takes with regen=0, and how much faster it is at regen=200.

This includes a change to the EP recovery ramp-up while in focus mode, so that it remains smooth if the speed is changed. I've tried to roughly approximate the original curve.

I'm resubmitting this pull request without including a compiled `RPG.lib` file, so that it can be more easily merged whenever you guys get around to doing so. :) Be sure to recompile it after you merge, of course.