### PR TITLE
Divide by zero in script “::AccelerativeShieldMod”

### DIFF
--- a/DoomRPG/scripts/Shield.ds
+++ b/DoomRPG/scripts/Shield.ds
@@ -1016,6 +1016,9 @@ script void LazyMod()
 
 script void AccelerativeShieldMod()
 {
+    if (Player.Shield.Capacity < 1)
+        return;
+
     int AccelCharge = Player.Shield.ChargeRate;
     AccelCharge += (Player.Shield.ChargeRate * 3) * Player.Shield.Charge / Player.Shield.Capacity;
     Player.Shield.ChargeRate = AccelCharge;


### PR DESCRIPTION
When attempting to equip the “MM-12” shield accessory without having any other shield parts equipped, the console is spammed with the above error message. The proposed change fixes that.