### PR TITLE
Allow the player to choose if/when monsters will constantly spawn.

### DIFF
--- a/DoomRPG/CVARINFO.txt
+++ b/DoomRPG/CVARINFO.txt
@@ -11,6 +11,7 @@ server	float	drpg_monster_random_max_mult = 1.2;
 server	int		drpg_aura_curve = 0;
 server  bool    drpg_monster_specialize = true;
 server  bool    drpg_monster_shadows = false;
+server	int	drpg_monster_constantspawn = 1;
 
 // Game Difficulty
 server	float   drpg_skill_costscale = 1.0;

--- a/DoomRPG/MENUDEF.txt
+++ b/DoomRPG/MENUDEF.txt
@@ -18,6 +18,13 @@ OptionValue "MonsterLevelType"
 	3, "Both"
 }
 
+OptionValue "MonsterConstantSpawnWhen"
+{
+	0, "Never"
+	1, "Hell difficulty"
+	2, "Always"
+}
+
 OptionValue "StatPreference"
 {
     -1, "None"
@@ -224,6 +231,7 @@ OptionMenu "DoomRPGMonsters"
     Option "Monster Stat Specialization", "drpg_monster_specialize", "OnOff"
     Option "Are You A Bad Enough Dude?", "drpg_monster_shadows", "YesNo"
 	Option "Fast Monsters", "sv_fastmonsters", "OnOff"
+	Option "Constant Monster Spawning", "drpg_monster_constantspawn", "MonsterConstantSpawnWhen"
 }
 
 OptionMenu "DoomRPGDifficulty"

--- a/DoomRPG/scripts/Map.ds
+++ b/DoomRPG/scripts/Map.ds
@@ -336,14 +336,20 @@ script void MapInit() open
     
     // Hell Skill has some additional challenges
     if (GameSkill() >= 5)
-    {
         AddMiniboss();
-        for (int i = 0; i < MAX_PLAYERS; i++)
+        
+    {
+        int ConstantSpawnSetting = GetCVar("drpg_monster_constantspawn");
+        
+        if ((ConstantSpawnSetting == 1 && GameSkill() >= 5) || ConstantSpawnSetting == 2)
         {
-            if (!PlayerInGame(i))
-                continue;
-            
-            HellSkillTransport(i);
+            for (int i = 0; i < MAX_PLAYERS; i++)
+            {
+                if (!PlayerInGame(i))
+                    continue;
+                
+                HellSkillTransport(i);
+            };
         };
     };
     


### PR DESCRIPTION
The proposed change adds a menu setting to control whether new monsters will constantly spawn on Hell difficulty and above, on any difficulty, or not at all.