### PR TITLE
Allow the player to customize the bonus aura chance that monsters get on Hell difficulty and above.

### DIFF
--- a/DoomRPG/CVARINFO.txt
+++ b/DoomRPG/CVARINFO.txt
@@ -9,6 +9,7 @@ server	float	drpg_monster_map_weight = 3.0;
 server	float	drpg_monster_random_min_mult = 0.8;
 server	float	drpg_monster_random_max_mult = 1.2;
 server	int		drpg_aura_curve = 0;
+server	int		drpg_aura_hell_chance = 20;
 server  bool    drpg_monster_specialize = true;
 server  bool    drpg_monster_shadows = false;
 

--- a/DoomRPG/MENUDEF.txt
+++ b/DoomRPG/MENUDEF.txt
@@ -219,6 +219,7 @@ OptionMenu "DoomRPGMonsters"
     Slider "Monster Random Min Multiplier", "drpg_monster_random_min_mult", 0.5, 10.0, 0.1
     Slider "Monster Random Max Multiplier", "drpg_monster_random_max_mult", 0.5, 10.0, 0.1
 	Slider "Monster Aura Curve", "drpg_aura_curve", -1000, 1000, 10
+	Slider "Hell difficulty monster aura chance %", "drpg_aura_hell_chance", 0, 100, 1
 	StaticText ""
     
     Option "Monster Stat Specialization", "drpg_monster_specialize", "OnOff"

--- a/DoomRPG/scripts/Monsters.ds
+++ b/DoomRPG/scripts/Monsters.ds
@@ -607,9 +607,9 @@ script void MonsterInitStats(int StatFlags)
             if (Players(i).Mission.Type == MT_KILLAURAS)
                 AuraMissionAdd += Players(i).Mission.Amount;
         
-        // Hell skill and above always has an additional +20% chance
+        // Hell skill and above always has an additional chance, based on settings
         if (GameSkill() >= 5)
-            AuraMissionAdd += 20;
+            AuraMissionAdd += GetCVar("drpg_aura_hell_chance");
         
         // 1st roll: Chance of having an aura at all
         bool HasAura = true;


### PR DESCRIPTION
The proposed change adds a menu setting that controls, on Hell difficulty and above, how much of an extra chance monsters get to have an aura.