### PR TITLE
Inventory resets don't deactivate shields.

### DIFF
--- a/DoomRPG/scripts/RPG.ds
+++ b/DoomRPG/scripts/RPG.ds
@@ -126,6 +126,7 @@ script void Init() enter
             
             SortStartingItems();
             DefaultLoadout();
+            DeactivateShield();
         };
     };
     


### PR DESCRIPTION
If a shield is active when undergoing an inventory reset (because of a death exit or `ResetInventory` in MAPINFO), the shield remains active upon entering the next map—but because there is no longer any shield in the inventory, it has a zero capacity. It also cannot be deactivated; trying to gives an error message that one or more shield parts is missing.

This PR deactivates the shield when newly entering a map, which seems to fix the problem.