### PR TITLE
Skill overdrive is easy to cheese. Here's an idea for fixing that.

### DIFF
--- a/DoomRPG-Extras/actors/extras/Player.txt
+++ b/DoomRPG-Extras/actors/extras/Player.txt
@@ -68,6 +68,9 @@ ACTOR DRPGDoomPlayerExtras : PlayerPawn
     Pain.Electric:
         TNT1 A 0 ACS_NamedExecuteAlways("SetDamageType", 0, DT_LIGHTNING)
         Goto Pain+1
+    Pain.DirectHealthDamage:
+        TNT1 A 0 ACS_NamedExecuteAlways("SetDamageType", 0, DT_DIRECT)
+        Goto Pain+1
     Death:
         PLAY H 0 A_Jump (128, 9)
         PLAY H 5 

--- a/DoomRPG-RLArsenal/actors/doomrl/Player.txt
+++ b/DoomRPG-RLArsenal/actors/doomrl/Player.txt
@@ -1328,6 +1328,9 @@ ACTOR DoomRLScoutRPG : DoomRLScout
 	TNT1 A 0 A_JumpIfInventory("RLSurvivalMediArmorToken",1,"SurvivalRegen")
 	TNT1 A 0 A_JumpIfInventory("RLOModSurvivalMediArmorToken",1,"SurvivalRegen")
     Goto Pain
+  Pain.DirectHealthDamage:
+	TNT1 A 0 ACS_NamedExecuteWithResult("SetDamageType", DT_DIRECT)
+    Goto Pain
   PlasmaAbsorb:
 	TNT1 A 0 A_GiveInventory("RLEnergyDischargeHarnessCounter",1)
 	TNT1 A 0 A_GiveInventory("RLEnergyDischargeHarnessPlasmaType",1)
@@ -2415,6 +2418,9 @@ ACTOR DoomRLTechnicianRPG : DoomRLTechnician
 	TNT1 A 0 A_JumpIfInventory("RLReactiveShieldSystemArmorToken",1,"MeleeAdapt")
 	TNT1 A 0 A_JumpIfInventory("RLSurvivalMediArmorToken",1,"SurvivalRegen")
 	TNT1 A 0 A_JumpIfInventory("RLOModSurvivalMediArmorToken",1,"SurvivalRegen")
+    Goto Pain
+  Pain.DirectHealthDamage:
+	TNT1 A 0 ACS_NamedExecuteWithResult("SetDamageType", DT_DIRECT)
     Goto Pain
   PlasmaAbsorb:
 	TNT1 A 0 A_GiveInventory("RLEnergyDischargeHarnessCounter",1)
@@ -3506,6 +3512,9 @@ ACTOR DoomRLRenegadeRPG : DoomRLRenegade
 	TNT1 A 0 A_JumpIfInventory("RLReactiveShieldSystemArmorToken",1,"MeleeAdapt")
 	TNT1 A 0 A_JumpIfInventory("RLSurvivalMediArmorToken",1,"SurvivalRegen")
 	TNT1 A 0 A_JumpIfInventory("RLOModSurvivalMediArmorToken",1,"SurvivalRegen")
+    Goto Pain
+  Pain.DirectHealthDamage:
+	TNT1 A 0 ACS_NamedExecuteWithResult("SetDamageType", DT_DIRECT)
     Goto Pain
   PlasmaAbsorb:
 	TNT1 A 0 A_GiveInventory("RLEnergyDischargeHarnessCounter",1)

--- a/DoomRPG-RLArsenal/actors/doomrl/Player.txt
+++ b/DoomRPG-RLArsenal/actors/doomrl/Player.txt
@@ -236,6 +236,9 @@ ACTOR DoomRLMarineRPG : DoomRLMarine
 	TNT1 A 0 A_JumpIfInventory("RLSurvivalMediArmorToken",1,"SurvivalRegen")
 	TNT1 A 0 A_JumpIfInventory("RLOModSurvivalMediArmorToken",1,"SurvivalRegen")
     Goto Pain
+  Pain.DirectHealthDamage:
+	TNT1 A 0 ACS_NamedExecuteWithResult("SetDamageType", DT_DIRECT)
+    Goto Pain
   PlasmaAbsorb:
 	TNT1 A 0 A_GiveInventory("RLEnergyDischargeHarnessCounter",1)
 	TNT1 A 0 A_GiveInventory("RLEnergyDischargeHarnessPlasmaType",1)

--- a/DoomRPG/DECORATE.txt
+++ b/DoomRPG/DECORATE.txt
@@ -21,6 +21,7 @@ const int DT_MELEE = 3;
 const int DT_FIRE = 4;
 const int DT_PLASMA = 5;
 const int DT_LIGHTNING = 6;
+const int DT_DIRECT = 7;
 
 // Status Effects
 const int SE_BLIND = 0;

--- a/DoomRPG/actors/DamageTypes.txt
+++ b/DoomRPG/actors/DamageTypes.txt
@@ -36,3 +36,10 @@ DamageType Shadow
 {
     NoArmor
 }
+
+// Damage that bypasses shields and armor. Used for damage from overdriving a skill.
+DamageType DirectHealthDamage
+{
+    ReplaceFactor
+    NoArmor
+}

--- a/DoomRPG/actors/Player.txt
+++ b/DoomRPG/actors/Player.txt
@@ -43,5 +43,8 @@ ACTOR DRPGDoomPlayer : DoomPlayer
     Pain.Electric:
         TNT1 A 0 ACS_NamedExecuteAlways("SetDamageType", 0, DT_LIGHTNING)
         Goto Pain+1
+    Pain.DirectHealthDamage:
+        TNT1 A 0 ACS_NamedExecuteAlways("SetDamageType", 0, DT_DIRECT)
+        Goto Pain+1
     }
 }

--- a/DoomRPG/scripts/HUD.ds
+++ b/DoomRPG/scripts/HUD.ds
@@ -988,7 +988,7 @@ script void DamageHUD(int Amount, bool Critical)
     // Color
     switch (Player.DamageType)
     {
-    case DT_NORMAL:                     Color = CR_WHITE;       break;
+    case DT_NORMAL: case DT_DIRECT:     Color = CR_WHITE;       break;
     case DT_TOXIC: case DT_RADIATION:   Color = CR_GREEN;       break;
     case DT_MELEE:                      Color = CR_GREY;        break;
     case DT_FIRE:                       Color = CR_RED;         break;

--- a/DoomRPG/scripts/RPG.ds
+++ b/DoomRPG/scripts/RPG.ds
@@ -439,68 +439,71 @@ script void PlayerDamage()
     DamageTaken = BeforeDamage - GetActorProperty(Player.TID, APROP_Health);
     ShieldDamageAmount = 0;
     
-    if (DamageTaken > 0)
+    if (Player.DamageType != DT_DIRECT)
     {
-        Player.AutosaveTimerReset = true;
-        
-        // Find Monster ID
-        MonsterID = FindMonster(Player.DamageTID);
-        
-        // Calculate monster crit/status chance
-        LuckChance = (fixed)Monsters[MonsterID].Luck / 20.0;
-        EnergyLevel = (fixed)Monsters[MonsterID].Energy / 12.5;
-        
-        // Calculate a critical hit
-        if (Player.DamageTID > 0 && MonsterID > 0)
-            if (RandomFixed(0.0, 100.0) <= EnergyLevel)
-            {
-                DamageTaken *= 2;
-                Critical = true;
-            };
-        
-        AugDamage(DamageTaken);
-        ToxicityDamage();
-        if (MonsterID > 0)
-            StatusDamage(DamageTaken, LuckChance, Critical)
-        else
-            StatusDamage(DamageTaken, RandomFixed(0.0, 100.0), Critical);
-        ResetRegen();
-        DamageHUD(DamageTaken, Critical);
-    };
-    
-    // Reset attacker's ID and critical damage state
-    Player.DamageTID = -1;
-    Critical = false;
-    
-    if (DamageTaken > 0 && Player.Shield.Active)
-        ShieldTimerReset();
-    
-    if (DamageTaken > 0 && Player.Shield.Active && Player.Shield.Charge > 0)
-    {
-        ShieldDamageAmount = DamageTaken; // For callback
-        if (ShieldDamageAmount > Player.Shield.Charge)
-            ShieldDamageAmount = Player.Shield.Charge;
-        
-        Player.Shield.Charge -= DamageTaken;
-        Player.Shield.Full = false;
-        
-        ShieldDamage(ShieldDamageAmount);
-        
-        if (Player.Shield.Charge <= 0)
+        if (DamageTaken > 0)
         {
-            if (Player.Shield.Charge < 0)
+            Player.AutosaveTimerReset = true;
+            
+            // Find Monster ID
+            MonsterID = FindMonster(Player.DamageTID);
+            
+            // Calculate monster crit/status chance
+            LuckChance = (fixed)Monsters[MonsterID].Luck / 20.0;
+            EnergyLevel = (fixed)Monsters[MonsterID].Energy / 12.5;
+            
+            // Calculate a critical hit
+            if (Player.DamageTID > 0 && MonsterID > 0)
+                if (RandomFixed(0.0, 100.0) <= EnergyLevel)
+                {
+                    DamageTaken *= 2;
+                    Critical = true;
+                };
+            
+            AugDamage(DamageTaken);
+            ToxicityDamage();
+            if (MonsterID > 0)
+                StatusDamage(DamageTaken, LuckChance, Critical)
+            else
+                StatusDamage(DamageTaken, RandomFixed(0.0, 100.0), Critical);
+            ResetRegen();
+            DamageHUD(DamageTaken, Critical);
+        };
+        
+        // Reset attacker's ID and critical damage state
+        Player.DamageTID = -1;
+        Critical = false;
+        
+        if (DamageTaken > 0 && Player.Shield.Active)
+            ShieldTimerReset();
+        
+        if (DamageTaken > 0 && Player.Shield.Active && Player.Shield.Charge > 0)
+        {
+            ShieldDamageAmount = DamageTaken; // For callback
+            if (ShieldDamageAmount > Player.Shield.Charge)
+                ShieldDamageAmount = Player.Shield.Charge;
+            
+            Player.Shield.Charge -= DamageTaken;
+            Player.Shield.Full = false;
+            
+            ShieldDamage(ShieldDamageAmount);
+            
+            if (Player.Shield.Charge <= 0)
             {
-                DamageTaken = -Player.Shield.Charge;
-                Player.ActualHealth -= DamageTaken;
-                Player.Shield.Charge = 0;
+                if (Player.Shield.Charge < 0)
+                {
+                    DamageTaken = -Player.Shield.Charge;
+                    Player.ActualHealth -= DamageTaken;
+                    Player.Shield.Charge = 0;
+                }
+                else
+                    DamageTaken = 0;
+                
+                ShieldBroken();
             }
             else
                 DamageTaken = 0;
-            
-            ShieldBroken();
-        }
-        else
-            DamageTaken = 0;
+        };
     };
     
     if (DamageTaken > 0)
@@ -658,7 +661,7 @@ acscript void GiveTip()
         
         // Skills
         { "\cnEP";                              "Energy Points are needed in order to use skills. They can also be used to charge your Shield and to deposit and withdraw items from your personal locker while not in the Outpost."; };
-        { "\cnOverdrive";                       StrParam("You can Overdrive a skill by holding the \cd%K\c- button. Doing this will always use the skill, regardless of it's EP cost. However, this will bring your current EP into the negatives. When negative, you will suffer stat penalties and not be able to use any skills until your EP is restored past 0.\n", "+speed"); };
+        { "\cnOverdrive";                       StrParam("You can Overdrive a skill by holding the \cd%K\c- button. Doing this will always use the skill, regardless of it's EP cost. However, this will bring your current EP into the negatives. When negative, you will suffer stat penalties and not be able to use any skills until your EP is restored past 0. Push it too far, and you'll also lose health!\n", "+speed"); };
         { "\cnAuras";                           "Auras are special passive abilities you can activate to give you temporary boosts to your stats. Auras will also affect teammates within it's radius, determined by your Energy stat"; };
         
         // Augmentations

--- a/DoomRPG/scripts/Skills.ds
+++ b/DoomRPG/scripts/Skills.ds
@@ -752,7 +752,19 @@ acscript void UseSkill(int Key) net
             
             // EFF-C13 Shield Accessory
             if (!Player.Shield.Accessory || Player.Shield.Accessory->PassiveEffect != SHIELD_PASS_MORESKILLS || Random(1, 4) == 1)
+            {
+                int EPMin = -Player.EPMax / 2;
                 Player.EP -= EPCost;
+                
+                if (Player.EP < EPMin)
+                {
+                    // Overdriving *too* hard will hurt!
+                    int OverdriveDamage = EPMin - Player.EP;
+                    Log("Overdriving this skill has damaged your health!\n");
+                    Player.EP = EPMin;
+                    Thing_Damage2(0, OverdriveDamage, "DirectHealthDamage");
+                };
+            };
             
             // TUFF-MAG3 Shield Accessory
             if (Player.Shield.Active && Player.Shield.Accessory && Player.Shield.Accessory->PassiveEffect == SHIELD_PASS_SKILLTOSHIELD)

--- a/DoomRPG/scripts/inc/Defs.dh
+++ b/DoomRPG/scripts/inc/Defs.dh
@@ -504,6 +504,7 @@ enum EDamageTypes
     DT_FIRE,
     DT_PLASMA,
     DT_LIGHTNING,
+    DT_DIRECT,
     DT_MAX
 };
 


### PR DESCRIPTION
Currently, it is easy to cheese the game by overdriving high-end summons at low levels. Just summon a Spider Overmind, then sit back and let it win the map (the portions it can reach, anyway) for you. All it costs you is 750 modules. Lame.

This PR adds a punishment for trying that. If overdriving a skill would bring EP below (-(EPmax / 2)), then the remainder becomes health damage instead. That way, you can safely overdrive skills that aren't too far beyond your abilities, but not ones that are way beyond you. This also means that, if you have little EP but tons of HP, you can survive a severe overdrive through sheer brute toughness instead.