### PR TITLE
Technicians can use shields slightly better.

### DIFF
--- a/DoomRPG/scripts/Shield.ds
+++ b/DoomRPG/scripts/Shield.ds
@@ -1595,6 +1595,14 @@ function void CheckShields()
     Player.Shield.ChargeRate = (BodyPtr ? BodyPtr->ChargeRate : 0) + (BatteryPtr ? BatteryPtr->ChargeRate : 0) + (CapacitorPtr ? CapacitorPtr->ChargeRate : 0);
     Player.Shield.DelayRate = 5.0 + (BodyPtr ? BodyPtr->DelayRate : 0) + (BatteryPtr ? BatteryPtr->DelayRate : 0) + (CapacitorPtr ? CapacitorPtr->DelayRate : 0);
     Player.Shield.Interval = 35;
+    
+    if (CompatMode == COMPAT_DRLA && PlayerClass(PlayerNumber()) == 2)
+    {
+        // Technicians can use shields slightly better.
+        Player.Shield.Capacity += Player.Shield.Capacity >> 3;
+        Player.Shield.ChargeRate += 2;
+        Player.Shield.DelayRate -= 2;
+    };
 };
 
 function void CheckShieldAccessory()


### PR DESCRIPTION
With this PR, in a technician's hands, shields have 12.5% more capacity, the charge rate is increased by 2, and the charge delay is decreased by 2.

Presently, the technician class' special abilities are a bit lacking compared to the other classes. His big thing in DRLA is that he can carry more modpacks and break down weapons, but in DRPG, the shop and locker make these advantages redundant. He does also have better luck with crates and can upgrade turrets more cheaply, which is good, but I thought he needed a little something extra to balance him out.

Since he specializes in customizing and optimizing his equipment, it seems fitting that he make better use of shields than the other classes. Thus, this PR.