### PR TITLE
For collect missions, show how many of the item you already have.

### DIFF
--- a/DoomRPG/scripts/Utils.ds
+++ b/DoomRPG/scripts/Utils.ds
@@ -1726,7 +1726,7 @@ function void DrawMissionInfo(MissionInfo *Mission, fixed X, fixed Y, bool Activ
         if (Active)
             HudMessage("Amount: \cd%d / %d\n", Mission->Current, Mission->Amount, HUDMSG_PLAIN, 0, CR_WHITE, X + 0.1, Y + 144.0, 0.05)
         else
-            HudMessage("Amount: \cd%d\n", Mission->Amount, HUDMSG_PLAIN, 0, CR_WHITE, X + 0.1, Y + 144.0, 0.05);
+            HudMessage("Amount: \cd%3d\c-        You have: \cd%3d\n", Mission->Amount, CheckInventory(Mission->Item->Actor), HUDMSG_PLAIN, 0, CR_WHITE, X + 0.1, Y + 144.0, 0.05);
         break;
     case MT_KILL:
         HudMessage("Type: \cg%s\n", Mission->Monster->Name, HUDMSG_PLAIN, 0, CR_WHITE, X + 0.1, Y + 128.0, 0.05);


### PR DESCRIPTION
This changes the Outpost Mission BBS such that, when viewing a collect mission, you can see how many of the required item you already have.