### PR TITLE
Automatic reactivation of augs disabled by EMP.

### DIFF
--- a/DoomRPG/CVARINFO.txt
+++ b/DoomRPG/CVARINFO.txt
@@ -162,6 +162,7 @@ server	int		drpg_autosave = 5;
 server  float   drpg_monster_dropdist = 4.0;
 server  bool    drpg_transport_on_new_map = false;
 server	bool	drpg_shotguns = false;
+user    bool    drpg_augs_autoreactivate = false;
 
 // Stored Character
 user    int     drpg_char_data_len = 0;

--- a/DoomRPG/KEYCONF.txt
+++ b/DoomRPG/KEYCONF.txt
@@ -79,3 +79,7 @@ alias drpg_useskill_7 "pukename UseSkill 7"
 // Quick Use Skill 8
 addmenukey "Quick Use Skill 8" drpg_useskill_8
 alias drpg_useskill_8 "pukename UseSkill 8"
+
+// Reactivate disabled augs
+addmenukey "Reactivate disabled augs" drpg_augs_reactivate
+alias drpg_augs_reactivate "pukename ReactivateDisabledAugs"

--- a/DoomRPG/MENUDEF.txt
+++ b/DoomRPG/MENUDEF.txt
@@ -502,6 +502,7 @@ OptionMenu "DoomRPGMisc"
     
     Slider "Rank Payout Interval (Minutes)", "drpg_pay_interval", 5, 60, 1
 	Slider "Autosave Interval (Minutes)", "drpg_autosave", 0, 60, 1
+	Option "Auto reactivate augs disabled by EMP", "drpg_augs_autoreactivate", "OnOff"
     StaticText ""
     
     Slider "Monster Drop Distance", "drpg_monster_dropdist", 0.1, 16.0, 0.1

--- a/DoomRPG/scripts/Augs.ds
+++ b/DoomRPG/scripts/Augs.ds
@@ -161,6 +161,33 @@ acscript void DisableAugs(bool NoDrain)
     ActivatorSound("aug/disable", 127);
 };
 
+acscript void ReactivateDisabledAugs() net
+{
+    // Check that we *can* activate augs.
+    if (Player.StatusType[SE_EMP] || Player.Augs.Battery <= 0)
+        return;
+    
+    for (int i = 0; i < AUG_MAX; i++)
+    {
+        // If there aren't enough slots left to equip any more augs, then don't try to activate any more.
+        if (Player.Augs.SlotsUsed >= Player.Augs.Slots)
+            break;
+        
+        if (CheckInventory(AugData[i].TokenActor) && !Player.Augs.Active[i] && Player.Augs.Level[i] > 0)
+            EquipAug(i);
+    };
+    
+    ClearDisabledAugs();
+};
+
+function void ClearDisabledAugs()
+{
+    for (int i = 0; i < AUG_MAX; i++)
+    {
+        TakeInventory(AugData[i].TokenActor, AugData[i].MaxLevel);
+    };
+};
+
 acscript void AddBattery(int Amount)
 {
     int PrevBattery = Player.Augs.Battery;

--- a/DoomRPG/scripts/Augs.ds
+++ b/DoomRPG/scripts/Augs.ds
@@ -26,6 +26,7 @@ AugSpace AugInfo[AUG_MAX] AugData =
             "3x Damage";
             "4x Damage";
         };
+        "DRPGAugTokenStrength";
     };
     {
         "Dermal Armor"; 5;
@@ -36,6 +37,7 @@ AugSpace AugInfo[AUG_MAX] AugData =
             "+20% Damage Reduction";
             "+25% Damage Reduction";
         };
+        "DRPGAugTokenDefense";
     };
     {
         "Pain Inhibitor"; 7;
@@ -48,6 +50,7 @@ AugSpace AugInfo[AUG_MAX] AugData =
             "+20% Status Effect Resist";
             "+25% Status Effect Resist";
         };
+        "DRPGAugTokenVitality";
     };
     {
         "Psi Projector"; 9;
@@ -62,6 +65,7 @@ AugSpace AugInfo[AUG_MAX] AugData =
             "20% Skill Cost Refund";
             "25% Skill Cost Refund";
         };
+        "DRPGAugTokenEnergy";
     };
     {
         "Adrenaline Booster"; 8;
@@ -75,6 +79,7 @@ AugSpace AugInfo[AUG_MAX] AugData =
             "+15 Second Toxicity Regen Time";
             "+20 Second Toxicity Regen Time";
         };
+        "DRPGAugTokenRegen";
     };
     {
         "Wired Reflexes"; 4;
@@ -88,6 +93,7 @@ AugSpace AugInfo[AUG_MAX] AugData =
             "+20% Survival Chance";
             "+25% Survival Chance";
         };
+        "DRPGAugTokenAgility";
     };
     {
         "Weight Distributor"; 3;
@@ -96,6 +102,7 @@ AugSpace AugInfo[AUG_MAX] AugData =
             "4x Ammo Limits";
             "2x Stim Vial Capacity";
         };
+        "DRPGAugTokenCapacity";
     };
     {
         "Precognition Unit"; 6;
@@ -107,6 +114,7 @@ AugSpace AugInfo[AUG_MAX] AugData =
             "3x Luck Drop Chances";
             "4x Luck Drop Chances";
         };
+        "DRPGAugTokenLuck";
     };
     {
         "Battery Recharger"; 8;
@@ -120,24 +128,12 @@ AugSpace AugInfo[AUG_MAX] AugData =
             "+3.5 Recharge Rate";
             "+4 Recharge Rate";
         };
+        "DRPGAugTokenBattery";
     };
 };
 
 acscript void DisableAugs(bool NoDrain)
 {
-    auto str[AUG_MAX] AugTokens =
-    {
-        "DRPGAugTokenStrength";
-        "DRPGAugTokenDefense";
-        "DRPGAugTokenVitality";
-        "DRPGAugTokenEnergy";
-        "DRPGAugTokenRegen";
-        "DRPGAugTokenAgility";
-        "DRPGAugTokenCapacity";
-        "DRPGAugTokenLuck";
-        "DRPGAugTokenBattery";
-    };
-    
     // Disable Augs and give tokens designating which Augs were disabled
     for (int i = 0; i < AUG_MAX; i++)
     {
@@ -145,14 +141,13 @@ acscript void DisableAugs(bool NoDrain)
         {
             // Disable Aug
             Player.Augs.Active[i] = false;
+            SetInventory(AugData[i].TokenActor, Player.Augs.Level[i]);
             
             // Screen fuckery
             SetHudSize(640, 480, false);
             SetFont("AugDView");
             HudMessage("A\n", HUDMSG_FADEOUT | HUDMSG_ADDBLEND, 0, CR_UNTRANSLATED, 320.0, 240.0, 3.0, 0.5);
         };
-        
-        SetInventory(AugTokens[i], Player.Augs.Level[i]);
     };
     
     // Reset Aug slots

--- a/DoomRPG/scripts/Menu.ds
+++ b/DoomRPG/scripts/Menu.ds
@@ -1769,7 +1769,12 @@ function void MenuInput()
             Player.MenuIndex++;
         };
         if (Buttons == BT_USE && OldButtons != BT_USE)
+        {
             EquipAug(Player.MenuIndex);
+            
+            // If the player starts manually toggling augs, don't try to automatically activate any later.
+            ClearDisabledAugs();
+        };
         if (Buttons & BT_SPEED && !(OldButtons & BT_SPEED))
             LevelUpAug(Player.MenuIndex);
     };

--- a/DoomRPG/scripts/Stats.ds
+++ b/DoomRPG/scripts/Stats.ds
@@ -1141,7 +1141,9 @@ function void CheckStatusEffects()
             DisableAugs(true);
         if ((Timer() % 35) == 0)
             Player.Augs.Battery -= Player.StatusIntensity[SE_EMP];
-    };
+    }
+    else if (GetActivatorCVar("drpg_augs_autoreactivate"))
+        ReactivateDisabledAugs();
     
     if (Player.StatusType[SE_RADIATION]) // Radiation
     {

--- a/DoomRPG/scripts/inc/Augs.dh
+++ b/DoomRPG/scripts/inc/Augs.dh
@@ -8,6 +8,7 @@ struct AugInfo
     str Name;
     int MaxLevel;
     str[MAX_AUG_LEVEL] Description;
+    str TokenActor;
 };
 
 AddressSpaceDecl MapArray AugSpace;

--- a/DoomRPG/scripts/inc/Augs.dh
+++ b/DoomRPG/scripts/inc/Augs.dh
@@ -19,6 +19,7 @@ extern variable AugSpace AugInfo[AUG_MAX] AugData;
 extern "ACS"
 {
     script void DisableAugs(bool = false);
+    script void ReactivateDisabledAugs();
     script void AddBattery(int);
 };
 
@@ -29,6 +30,7 @@ extern
     function void EquipAug(int);
     function void LevelUpAug(int);
     function void AugDamage(int);
+    function void ClearDisabledAugs();
 };
 
 #endif


### PR DESCRIPTION
This PR adds two related features: a key binding to reactivate augs that were disabled by a previous EMP, and an option to do so automatically when the EMP wears off.