### PR TITLE
Add an option for disabling the Sinstorm event.

### DIFF
--- a/DoomRPG/CVARINFO.txt
+++ b/DoomRPG/CVARINFO.txt
@@ -28,6 +28,7 @@ server	float	drpg_mapevent_chance = 10.0;
 server	int		drpg_mapevent_eventtime = 10;
 server  int     drpg_default_par_seconds = 180;
 server  bool    drpg_bonus_events = true;
+server  bool    drpg_sinstorm = true;
 server  bool    drpg_loot_system = true;
 server  float   drpg_lootgen_factor = 1.0;
 

--- a/DoomRPG/MENUDEF.txt
+++ b/DoomRPG/MENUDEF.txt
@@ -253,6 +253,7 @@ OptionMenu "DoomRPGDifficulty"
 	Slider "Event Interval (Minutes)", "drpg_mapevent_eventtime", 0, 120, 1
     Slider "Default Event Par (Seconds)", "drpg_default_par_seconds", 30, 600, 15
     Option "Bonus Events", "drpg_bonus_events", "OnOff"
+    Option "Special event on MAP30", "drpg_sinstorm", "OnOff"
 	StaticText ""
 	
     Option "Dynamic Loot System", "drpg_loot_system", "OnOff"

--- a/DoomRPG/scripts/Map.ds
+++ b/DoomRPG/scripts/Map.ds
@@ -1185,7 +1185,7 @@ script void DecideMapEvent(LevelInfo *TargetLevel, bool FakeIt)
         // Tags: 666 (Floor_LowerToLowest), 667 (Floor_RaiseByTexture)
         return;
     }
-    else if (!StrICmp(TargetLevel->LumpName, "MAP30"))
+    else if (!StrICmp(TargetLevel->LumpName, "MAP30") && GetCVar("drpg_sinstorm"))
     {
         // Icon of Sin
         // Blurb about a demon spitter and the game ending finale here.


### PR DESCRIPTION
The Sinstorm event, though awesome, does change MAP30 rather dramatically. The player may not want that. This PR adds an option to turn it off.