### PR TITLE
When upgrading a stat with modules, don't lose its accumulated stat XP.

### DIFF
--- a/DoomRPG/scripts/Menu.ds
+++ b/DoomRPG/scripts/Menu.ds
@@ -2117,7 +2117,15 @@ function void IncreaseStat(int Stat)
     if (*Stats[Stat] < Player.StatCap)
     {
         if (GetCVar("drpg_levelup_natural")) // Natural Leveling
-            *StatXP[Stat] = StatTable[*Stats[Stat]]
+        {
+            long int CurrentXP = *StatXP[Stat];
+            long int LastXP = StatTable[*Stats[Stat] - 1];
+            long int NextXP = StatTable[*Stats[Stat]];
+            if (*Stats[Stat] == 0)
+                LastXP = 0;
+            
+            *StatXP[Stat] = NextXP + (CurrentXP - LastXP);
+        }
         else
             (*Stats[Stat])++;
     }


### PR DESCRIPTION
Currently, when you upgrade a stat via the Stats menu, any XP it had accumulated via natural stat growth is lost. Upgrading a stat that's almost leveled up naturally is a waste of perfectly good modules. This PR fixes that by preserving the XP it has accumulated since the previous level.