### PR TITLE
Add an option to make auto-sell fall back to auto-deposit.

### DIFF
--- a/DoomRPG/CVARINFO.txt
+++ b/DoomRPG/CVARINFO.txt
@@ -93,6 +93,7 @@ server  int     drpg_shopspecial_min = 0;
 server  int     drpg_shopspecial_max = 1000000;
 server  int     drpg_shopspecial_discount = 25;
 user    int     drpg_pickup_behavior = 0;
+user    bool    drpg_autosell_lockerfallback = false;
 
 // Turret
 user    int     drpg_turret_aggression = 0;

--- a/DoomRPG/MENUDEF.txt
+++ b/DoomRPG/MENUDEF.txt
@@ -377,6 +377,11 @@ OptionMenu "DoomRPGShop"
     StaticText ""
     
     Option "Run Pickup Behavior", "drpg_pickup_behavior", "RunPickupBehavior"
+    StaticText ""
+    
+    StaticText "When picking up an item that you've set to auto-sell"
+    StaticText "but can't actually sell it at the moment"
+    Option "auto-deposit it in the locker instead", "drpg_autosell_lockerfallback", "OnOff"
 }
 
 OptionMenu "DoomRPGTurret"

--- a/DoomRPG/scripts/Shop.ds
+++ b/DoomRPG/scripts/Shop.ds
@@ -76,6 +76,23 @@ script void UpdateShopAutoList()
         };
 };
 
+function void ShopItemTryAutoDeposit(ItemInfoPtr Item)
+{
+    bool deposited = false;
+    
+    // Special handling for DRLA weapons since you can only keep one weapon with mods in the locker
+    if (CompatMode == COMPAT_DRLA && Item->Category == 0 && Player.Locker[Item->Category][Item->Index] > 0) return;
+    
+    while (CheckInventory(Item->Actor) > 0 && (Player.EP >= LOCKER_EPRATE || CurrentLevel->UACBase))
+    {
+        DepositItem(Item->Category, Item->Index, false, true);
+        deposited = true;
+    };
+    
+    if (deposited)
+        ActivatorSound("shop/autostore", 127);
+};
+
 script void ShopItemAutoHandler()
 {
     int[ITEM_CATEGORIES][ITEM_MAX] Items;
@@ -94,36 +111,30 @@ script void ShopItemAutoHandler()
                     Items[i][j] = CheckInventory(ItemData[i][j].Actor);
         
         // Auto-Sell
-        if (Player.RankLevel > 0 || CurrentLevel->UACBase)
+        bool CanSellItems = Player.RankLevel > 0 || CurrentLevel->UACBase;
+        bool UseAutoDepositFallback = GetActivatorCVar("drpg_autosell_lockerfallback");
+        if (CanSellItems || UseAutoDepositFallback)
             for (int i = 0; i < Player.AutoSellList.Position; i++)
             {
                 ItemInfoPtr Item = ((ItemInfoPtr *)Player.AutoSellList.Data)[i];
                 
                 if (CheckInventory(Item->Actor) > 0)
-                    SellItem(Item->Actor, true, true);
+                {
+                    if (CanSellItems)
+                        SellItem(Item->Actor, true, true)
+                    else if (UseAutoDepositFallback)
+                        ShopItemTryAutoDeposit(Item);
+                };
             };
         
         // Auto-Store
-        bool deposited = false;
         if (Player.EP >= LOCKER_EPRATE || CurrentLevel->UACBase)
             for (int i = 0; i < Player.AutoStoreList.Position; i++)
             {
                 ItemInfoPtr Item = ((ItemInfoPtr *)Player.AutoStoreList.Data)[i];
                 
                 if (CheckInventory(Item->Actor) > 0)
-                {
-                    // Special handling for DRLA weapons since you can only keep one weapon with mods in the locker
-                    if (CompatMode == COMPAT_DRLA && Item->Category == 0 && Player.Locker[Item->Category][Item->Index] > 0) continue;
-                    
-                    while (CheckInventory(Item->Actor) > 0 && (Player.EP >= LOCKER_EPRATE || CurrentLevel->UACBase))
-                    {
-                        DepositItem(Item->Category, Item->Index, false, true);
-                        deposited = true;
-                    };
-                    
-                    if (deposited)
-                        ActivatorSound("shop/autostore", 127);
-                };
+                    ShopItemTryAutoDeposit(Item);
             };
         
         // Run-pickup behavior stuff
@@ -134,7 +145,6 @@ script void ShopItemAutoHandler()
                 {
                     ItemInfoPtr Item = &ItemData[i][j];
                     
-                    bool deposited = false;
                     // Auto-Sell
                     if (!Player.InShop && GetActivatorCVar("drpg_pickup_behavior") == 1 && Items[i][j] > PrevItems[i][j])
                         if (CheckInventory(Item->Actor) > 0)
@@ -142,20 +152,7 @@ script void ShopItemAutoHandler()
                     
                     // Auto-Store
                     if (!Player.InShop && GetActivatorCVar("drpg_pickup_behavior") == 2 && Items[i][j] > PrevItems[i][j])
-                        if (CheckInventory(Item->Actor) > 0)
-                        {
-                            // Special handling for DRLA weapons since you can only keep one weapon with mods in the locker
-                            if (CompatMode == COMPAT_DRLA && i == 0 && Player.Locker[i][j] > 0) continue;
-                            
-                            while (CheckInventory(Item->Actor) > 0 && (Player.EP >= LOCKER_EPRATE || CurrentLevel->UACBase))
-                            {
-                                DepositItem(i, j, false, true);
-                                deposited = true;
-                            };
-                        };
-                    
-                    if (deposited)
-                        ActivatorSound("shop/autostore", 127);
+                        ShopItemTryAutoDeposit(Item);
                 };
         };
         


### PR DESCRIPTION
When you're first starting out at rank 0, you can't yet sell items outside of the Outpost, but that doesn't mean you have to carry them around until you rank up or return to the Outpost; you can still deposit them in the locker.

This commit adds an option that, if turned on, automates this. When picking up an item that you've set to auto-sell, but can't actually sell it at the moment, you'll automatically deposit it in the locker instead. Normal auto-sell behavior still applies if you're at least rank 1 or are in the Outpost.