### PR TITLE
Destroyed turret parts sometimes spawn in unreachable places.

### DIFF
--- a/DoomRPG/actors/Turret.txt
+++ b/DoomRPG/actors/Turret.txt
@@ -955,16 +955,36 @@ actor DRPGDestroyedTurret : SwitchableDecoration
         Loop
     Active:
     Disassemble:
-        TNT1 A 0 A_SpawnItemEx("DRPGTurretPart",
+        TNT1 A 0 A_SpawnItemEx("DRPGDestroyedTurretPartSpawner",
+            0, 0, 0,
             Cos(user_angleoff * user_loop) * 32,
             Sin(user_angleoff * user_loop) * 32,
-            CeilingZ - 8, 0, 0, 0)
+            0, 0, 0, 0)
         TNT1 A 0 A_SetUserVar("user_loop", user_loop - 1)
         TNT1 A 0 A_JumpIf(user_loop == 0, "Death")
         Loop
     Death:
         TNT1 A 0 A_PlaySound("misc/transport", CHAN_5, 1.0, false, 2.0)
         TNT1 A 0 A_SpawnItemEx("DRPGTurretTeleport")
+        Stop
+    }
+}
+
+Actor DRPGDestroyedTurretPartSpawner
+{
+    +NOBLOCKMAP
+    +NODROPOFF
+    +NOTELEPORT
+    +SLIDESONWALLS
+    
+    States
+    {
+    Spawn:
+        TNT1 A 1
+        Goto Death
+    
+    Death:
+        TNT1 A 0 A_SpawnItemEx("DRPGTurretPart")
         Stop
     }
 }


### PR DESCRIPTION
Currently, when the player loots a destroyed turret, the resulting turret parts appear in a circle around it. If it's next to a wall, some of them will appear *inside* the wall! Similarly, some of the parts might fall off a ledge, or climb up a ledge, to a spot that is visible but unreachable.

This PR has the game's physics engine make sure that the turret parts don't wind up anywhere you can't easily reach.