### PR TITLE
Fix Mental Mapping adding a "DRPGAllMapScanner" to inventory.

### DIFF
--- a/DoomRPG/actors/Powerups.txt
+++ b/DoomRPG/actors/Powerups.txt
@@ -364,6 +364,8 @@ actor DRPGAllMapRevealer : MapRevealer {}
 actor DRPGAllMapScanner : PowerupGiver
 {
     +INVENTORY.AUTOACTIVATE
+    -INVENTORY.INVBAR
+    Inventory.MaxAmount 0
 
     Powerup.Type Scanner
     Powerup.Duration -0x7FFFFFFF


### PR DESCRIPTION
I'm not entirely sure when it does this, but at any rate, this PR changes the DRPGAllMapScanner class such that it is never kept in the inventory. It is either activated immediately (if you don't already have the Scanner power) or discarded silently (if you do).