### PR TITLE
Workaround for issue #68

### DIFF
--- a/DoomRPG/scripts/Turret.ds
+++ b/DoomRPG/scripts/Turret.ds
@@ -549,6 +549,13 @@ script void TurretLoop() enter
         Player.Turret.PaidForRepair = true;
     };
     
+    // Sanity check. Without this, using `kill monsters` (or being really unlucky) while the turret is active will semi-destroy it, making it impossible to deploy or repair.
+    if (Player.Turret.Health >= Player.Turret.HealthMax)
+    {
+        Player.Turret.Destroyed = false;
+        Player.Turret.PaidForRepair = true;
+    };
+    
     while (Player.Turret.Active && Player.Turret.TID != 0)
     {
         // Pre-health check

--- a/DoomRPG/scripts/Turret.ds
+++ b/DoomRPG/scripts/Turret.ds
@@ -2349,8 +2349,8 @@ function bool TurretLoadAmmo(int Type)
 
 function void TurretCommand(int Index)
 {
-    // Don't issue the command if you don't have the base upgrade yet or your turret is destroyed or in maintenance
-    if (!Player.Turret.Upgrade[Index] || Player.Turret.Destroyed || Player.Turret.Maintenance) return;
+    // Don't issue the command if you don't have the base upgrade yet
+    if (!Player.Turret.Upgrade[Index]) return;
     
     if (Index == TU_BUILD)
     {
@@ -2359,6 +2359,9 @@ function void TurretCommand(int Index)
         else
             TurretSpawn();
     };
+    
+    // Do these checks after TurretSpawn/TurretDespawn, because TurretSpawn will print its own errors for these conditions, and these conditions aren't even possible for TurretDespawn.
+    if (Player.Turret.Destroyed || Player.Turret.Maintenance) return;
     
     if (Index == TU_WEAPON_BULLET && Player.Turret.Active)
     {


### PR DESCRIPTION
As described in issue #68, `kill monsters` was causing the turret to become “destroyed” without altering its health, making it impossible to deploy or repair. This works around that problem by checking every tic if its health is full, and if so, clearing the destroyed flag.