### PR TITLE
Vicious Downpour has terrible performance.

### DIFF
--- a/DoomRPG/actors/Event.txt
+++ b/DoomRPG/actors/Event.txt
@@ -1186,7 +1186,7 @@ actor DRPGViciousRain
         PTCL F -1
         stop
     Death:
-        PTCL FFFF 0 A_SpawnItemEx("DRPGViciousRainParticle", 0, 0, 8, FRandom(-4,4), 0, FRandom(1,4), FRandom(0, 360))
+        //PTCL FFFF 0 A_SpawnItemEx("DRPGViciousRainParticle", 0, 0, 8, FRandom(-4,4), 0, FRandom(1,4), FRandom(0, 360))
         PTCL F 0 A_Gravity
         PTCL F 0 A_SetScale(0.05, 0.01)
         PTCL F 35 A_RadiusGive("DRPGAcidRainDamage", 64, RGF_PLAYERS | RGF_CUBE)


### PR DESCRIPTION
This PR removes the raindrop splash effect in Vicious Downpour. While this effect looks really cool, it's also really bad for performance (at least on my machine).